### PR TITLE
Add GitHub and Claude API client adapters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,6 @@ repos:
     rev: v1.13.0
     hooks:
       - id: mypy
-        additional_dependencies: [temporalio, anthropic, pytest]
+        additional_dependencies: [temporalio, anthropic, pytest, PyGithub]
         args: [src]
         pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "temporalio>=1.8.0",
     "anthropic>=0.42.0",
+    "pygithub>=2.8.1",
 ]
 
 [build-system]

--- a/src/troller/worker/adapters/claude_client.py
+++ b/src/troller/worker/adapters/claude_client.py
@@ -1,0 +1,146 @@
+"""Claude API client adapter.
+
+Adapter for interacting with Claude AI via Anthropic SDK.
+"""
+
+import os
+from datetime import datetime
+from typing import Any
+
+from anthropic import Anthropic
+from anthropic.types import MessageParam, ToolParam
+
+from troller.domain.models.plan import Plan, PlanStep
+
+
+class ClaudeClient:
+    """Claude API client for generating implementation plans.
+
+    This is an adapter that wraps the Anthropic SDK to provide AI planning
+    capabilities. Authenticates using Anthropic API key from environment.
+    """
+
+    def __init__(self) -> None:
+        """Initialize Claude client with API key authentication.
+
+        Raises:
+            ValueError: If ANTHROPIC_API_KEY environment variable is not set.
+        """
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise ValueError("ANTHROPIC_API_KEY environment variable is required")
+
+        self._client = Anthropic(api_key=api_key)
+
+    def generate_plan(
+        self, issue_title: str, issue_body: str, issue_number: int
+    ) -> Plan:
+        """Generate an implementation plan from a GitHub issue.
+
+        Args:
+            issue_title: Title of the GitHub issue.
+            issue_body: Body/description of the GitHub issue.
+            issue_number: Issue number for reference.
+
+        Returns:
+            Plan domain object with implementation steps.
+        """
+        system_prompt = """You are a senior software architect analyzing GitHub issues to create implementation plans.
+
+Your task is to analyze the issue and create a structured implementation plan with:
+- A high-level summary of what needs to be done
+- Ordered implementation steps
+- Technical approach and architecture decisions
+- Testing strategy
+
+Keep plans simple and focused on the issue requirements."""
+
+        user_message = f"""Analyze this GitHub issue and create an implementation plan:
+
+Issue #{issue_number}: {issue_title}
+
+{issue_body}
+
+Create a structured plan with implementation steps."""
+
+        # Define the tool schema for structured output
+        tools: list[ToolParam] = [
+            {
+                "name": "create_plan",
+                "description": "Create a structured implementation plan",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "summary": {
+                            "type": "string",
+                            "description": "High-level summary of the plan",
+                        },
+                        "steps": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {"type": "string"},
+                                    "description": {"type": "string"},
+                                    "completed": {"type": "boolean"},
+                                    "related_files": {
+                                        "type": ["array", "null"],
+                                        "items": {"type": "string"},
+                                    },
+                                    "estimated_complexity": {
+                                        "type": ["string", "null"],
+                                        "enum": ["simple", "moderate", "complex", None],
+                                    },
+                                },
+                                "required": ["id", "description", "completed"],
+                            },
+                        },
+                        "technical_approach": {
+                            "type": ["string", "null"],
+                            "description": "Architecture decisions and technical approach",
+                        },
+                        "testing_strategy": {
+                            "type": ["string", "null"],
+                            "description": "How to test the implementation",
+                        },
+                    },
+                    "required": ["summary", "steps"],
+                },
+            }
+        ]
+
+        messages: list[MessageParam] = [{"role": "user", "content": user_message}]
+
+        response = self._client.messages.create(
+            model="claude-opus-4-5-20251101",
+            max_tokens=4096,
+            system=system_prompt,
+            messages=messages,
+            tools=tools,
+            tool_choice={"type": "tool", "name": "create_plan"},
+        )
+
+        # Extract the structured output from tool use
+        tool_use = next(block for block in response.content if block.type == "tool_use")
+        plan_data: dict[str, Any] = tool_use.input
+
+        # Convert to domain model
+        steps = [
+            PlanStep(
+                id=str(step["id"]),
+                description=str(step["description"]),
+                completed=bool(step["completed"]),
+                related_files=step.get("related_files"),
+                estimated_complexity=step.get("estimated_complexity"),
+            )
+            for step in plan_data["steps"]
+        ]
+
+        return Plan(
+            summary=str(plan_data["summary"]),
+            steps=steps,
+            created_at=datetime.now(),
+            metadata={"issue_number": issue_number},
+            technical_approach=plan_data.get("technical_approach"),
+            testing_strategy=plan_data.get("testing_strategy"),
+        )

--- a/src/troller/worker/adapters/github_client.py
+++ b/src/troller/worker/adapters/github_client.py
@@ -1,0 +1,44 @@
+"""GitHub API client adapter.
+
+Adapter for interacting with GitHub via PyGithub library.
+"""
+
+import os
+
+from github import Auth, Github
+from github.Issue import Issue as GithubIssue
+
+
+class GitHubClient:
+    """GitHub API client for fetching issues and repository information.
+
+    This is an adapter that wraps PyGithub to provide GitHub integration.
+    Authenticates using a GitHub personal access token from environment.
+    """
+
+    def __init__(self) -> None:
+        """Initialize GitHub client with token authentication.
+
+        Raises:
+            ValueError: If GITHUB_TOKEN environment variable is not set.
+        """
+        token = os.getenv("GITHUB_TOKEN")
+        if not token:
+            raise ValueError("GITHUB_TOKEN environment variable is required")
+
+        auth = Auth.Token(token)
+        self._client = Github(auth=auth)
+
+    def get_issue(self, owner: str, repo: str, issue_number: int) -> GithubIssue:
+        """Fetch a GitHub issue by repository and issue number.
+
+        Args:
+            owner: Repository owner (user or organization).
+            repo: Repository name.
+            issue_number: Issue number to fetch.
+
+        Returns:
+            PyGithub Issue object containing issue details.
+        """
+        repository = self._client.get_repo(f"{owner}/{repo}")
+        return repository.get_issue(issue_number)

--- a/tests/unit/worker/test_claude_client.py
+++ b/tests/unit/worker/test_claude_client.py
@@ -1,0 +1,150 @@
+"""Unit tests for Claude API client adapter."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from troller.domain.models.plan import Plan
+from troller.worker.adapters.claude_client import ClaudeClient
+
+
+class TestClaudeClient:
+    """Test suite for ClaudeClient adapter."""
+
+    def test_init_reads_api_key_from_env(self) -> None:
+        """ClaudeClient reads ANTHROPIC_API_KEY from environment."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            with patch(
+                "troller.worker.adapters.claude_client.Anthropic"
+            ) as mock_anthropic:
+                _client = ClaudeClient()
+
+                # Verify Anthropic was instantiated with API key
+                mock_anthropic.assert_called_once_with(api_key="test-key")
+
+    def test_init_raises_error_when_api_key_missing(self) -> None:
+        """ClaudeClient raises clear error when ANTHROPIC_API_KEY is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(
+                ValueError, match="ANTHROPIC_API_KEY environment variable is required"
+            ):
+                ClaudeClient()
+
+    def test_generate_plan_returns_plan_object(self) -> None:
+        """generate_plan returns Plan domain object."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            with patch(
+                "troller.worker.adapters.claude_client.Anthropic"
+            ) as mock_anthropic_class:
+                # Setup mock
+                mock_anthropic = MagicMock()
+                mock_anthropic_class.return_value = mock_anthropic
+
+                # Mock the response
+                mock_response = MagicMock()
+                mock_response.content = [
+                    MagicMock(
+                        type="tool_use",
+                        input={
+                            "summary": "Test plan summary",
+                            "steps": [
+                                {
+                                    "id": "step-1",
+                                    "description": "First step",
+                                    "completed": False,
+                                    "related_files": ["file.py"],
+                                    "estimated_complexity": "simple",
+                                }
+                            ],
+                            "technical_approach": "Test approach",
+                            "testing_strategy": "Test strategy",
+                        },
+                    )
+                ]
+                mock_anthropic.messages.create.return_value = mock_response
+
+                # Test
+                client = ClaudeClient()
+                plan = client.generate_plan(
+                    issue_title="Test Issue", issue_body="Test body", issue_number=123
+                )
+
+                # Verify
+                assert isinstance(plan, Plan)
+                assert plan.summary == "Test plan summary"
+                assert len(plan.steps) == 1
+                assert plan.steps[0].id == "step-1"
+                assert plan.technical_approach == "Test approach"
+                assert plan.testing_strategy == "Test strategy"
+
+    def test_generate_plan_uses_claude_opus_model(self) -> None:
+        """generate_plan uses Claude Opus 4.5 model."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            with patch(
+                "troller.worker.adapters.claude_client.Anthropic"
+            ) as mock_anthropic_class:
+                mock_anthropic = MagicMock()
+                mock_anthropic_class.return_value = mock_anthropic
+
+                mock_response = MagicMock()
+                mock_response.content = [
+                    MagicMock(
+                        type="tool_use",
+                        input={
+                            "summary": "Test",
+                            "steps": [],
+                            "technical_approach": None,
+                            "testing_strategy": None,
+                        },
+                    )
+                ]
+                mock_anthropic.messages.create.return_value = mock_response
+
+                client = ClaudeClient()
+                client.generate_plan(
+                    issue_title="Test", issue_body="Body", issue_number=1
+                )
+
+                # Verify model parameter
+                call_args = mock_anthropic.messages.create.call_args
+                assert call_args.kwargs["model"] == "claude-opus-4-5-20251101"
+
+    def test_generate_plan_includes_issue_context_in_prompt(self) -> None:
+        """generate_plan includes issue details in the prompt."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            with patch(
+                "troller.worker.adapters.claude_client.Anthropic"
+            ) as mock_anthropic_class:
+                mock_anthropic = MagicMock()
+                mock_anthropic_class.return_value = mock_anthropic
+
+                mock_response = MagicMock()
+                mock_response.content = [
+                    MagicMock(
+                        type="tool_use",
+                        input={
+                            "summary": "Test",
+                            "steps": [],
+                            "technical_approach": None,
+                            "testing_strategy": None,
+                        },
+                    )
+                ]
+                mock_anthropic.messages.create.return_value = mock_response
+
+                client = ClaudeClient()
+                client.generate_plan(
+                    issue_title="Add feature X",
+                    issue_body="Implement feature X with Y",
+                    issue_number=42,
+                )
+
+                # Verify issue details in messages
+                call_args = mock_anthropic.messages.create.call_args
+                messages = call_args.kwargs["messages"]
+                user_message = messages[0]["content"]
+
+                assert "Add feature X" in user_message
+                assert "Implement feature X with Y" in user_message
+                assert "42" in user_message

--- a/tests/unit/worker/test_github_client.py
+++ b/tests/unit/worker/test_github_client.py
@@ -1,0 +1,88 @@
+"""Unit tests for GitHub API client adapter."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from github import Auth
+from github.Issue import Issue as GithubIssue
+
+from troller.worker.adapters.github_client import GitHubClient
+
+
+class TestGitHubClient:
+    """Test suite for GitHubClient adapter."""
+
+    def test_init_reads_token_from_env(self) -> None:
+        """GitHubClient reads GITHUB_TOKEN from environment."""
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "test-token"}):
+            with patch("troller.worker.adapters.github_client.Github") as mock_github:
+                _client = GitHubClient()
+
+                # Verify Github was instantiated with token auth
+                mock_github.assert_called_once()
+                call_kwargs = mock_github.call_args.kwargs
+                assert "auth" in call_kwargs
+                auth = call_kwargs["auth"]
+                assert isinstance(auth, Auth.Token)
+
+    def test_init_raises_error_when_token_missing(self) -> None:
+        """GitHubClient raises clear error when GITHUB_TOKEN is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(
+                ValueError, match="GITHUB_TOKEN environment variable is required"
+            ):
+                GitHubClient()
+
+    def test_get_issue_fetches_issue_by_repo_and_number(self) -> None:
+        """get_issue fetches issue by owner, repo, and number."""
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "test-token"}):
+            with patch(
+                "troller.worker.adapters.github_client.Github"
+            ) as mock_github_class:
+                # Setup mock
+                mock_github = MagicMock()
+                mock_github_class.return_value = mock_github
+
+                mock_repo = MagicMock()
+                mock_github.get_repo.return_value = mock_repo
+
+                mock_issue = MagicMock(spec=GithubIssue)
+                mock_issue.number = 123
+                mock_issue.title = "Test Issue"
+                mock_issue.body = "Test body"
+                mock_repo.get_issue.return_value = mock_issue
+
+                # Test
+                client = GitHubClient()
+                issue = client.get_issue("owner", "repo", 123)
+
+                # Verify
+                mock_github.get_repo.assert_called_once_with("owner/repo")
+                mock_repo.get_issue.assert_called_once_with(123)
+                assert issue == mock_issue
+
+    def test_get_issue_returns_github_issue_object(self) -> None:
+        """get_issue returns PyGithub Issue object."""
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "test-token"}):
+            with patch(
+                "troller.worker.adapters.github_client.Github"
+            ) as mock_github_class:
+                # Setup mock
+                mock_github = MagicMock()
+                mock_github_class.return_value = mock_github
+
+                mock_repo = MagicMock()
+                mock_github.get_repo.return_value = mock_repo
+
+                mock_issue = MagicMock(spec=GithubIssue)
+                mock_repo.get_issue.return_value = mock_issue
+
+                # Test
+                client = GitHubClient()
+                issue = client.get_issue("owner", "repo", 1)
+
+                # Verify type
+                assert isinstance(
+                    issue, MagicMock
+                )  # In real usage, would be GithubIssue


### PR DESCRIPTION
## Summary

Implements two API client adapters following hexagonal architecture principles:

- **GitHub API Client (#2)**: Fetches issues using PyGithub
  - Reads `GITHUB_TOKEN` from environment
  - Provides `get_issue()` method for fetching by repo/number
  - Comprehensive unit tests with mocking

- **Claude API Client (#4)**: Generates implementation plans using Anthropic SDK
  - Reads `ANTHROPIC_API_KEY` from environment
  - Uses Claude Opus 4.5 model
  - Leverages structured outputs via tool calling for type-safe Plan objects
  - Returns domain model `Plan` objects

Both clients:
- Follow TDD approach (tests written first)
- Use Python 3.13+ type hints throughout
- Pass all code quality checks (ruff, mypy, pytest)
- Have zero `type: ignore` comments (proper typing instead)
- Include environment variable validation with clear error messages

## Test Plan

- [x] All unit tests pass (9 tests total)
- [x] Ruff linting passes
- [x] Ruff formatting passes
- [x] Mypy type checking passes (with PyGithub added to pre-commit)
- [x] Pre-commit hooks all pass

Run tests:
```bash
uv run pytest tests/unit/worker -v
uv run mypy src
uv run ruff check
```

## Technical Notes

**Structured Outputs**: The Claude client uses Anthropic's tool calling feature to enforce a strict schema for Plan objects, ensuring type safety and eliminating JSON parsing errors.

**Pre-commit Update**: Added PyGithub to mypy's `additional_dependencies` so type checking works in the pre-commit environment.

Closes #2
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)