### PR TITLE
Add commit hash tracking to Plans for change detection

### DIFF
--- a/src/troller/domain/models/plan.py
+++ b/src/troller/domain/models/plan.py
@@ -38,6 +38,7 @@ class Plan:
         technical_approach: Architecture decisions, libraries, and patterns to use.
         testing_strategy: How to test the implementation.
         metadata: Extensible metadata for additional context (issue_number, etc.).
+        based_on_commit: Git commit SHA the plan was based on for change detection.
     """
 
     summary: str
@@ -46,3 +47,4 @@ class Plan:
     technical_approach: str | None = None
     testing_strategy: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    based_on_commit: str | None = None

--- a/src/troller/worker/adapters/repo_cloner.py
+++ b/src/troller/worker/adapters/repo_cloner.py
@@ -18,7 +18,7 @@ class RepoCloner:
 
     async def clone_to_temp(
         self, repo_owner: str, repo_name: str, target_branch: str | None = None
-    ) -> tuple[Path, Path]:
+    ) -> tuple[Path, Path, str]:
         """Clone repository to temporary directory with branch fallback.
 
         Clones a GitHub repository to a temporary directory using shallow clone
@@ -31,9 +31,10 @@ class RepoCloner:
             target_branch: Specific branch to clone. If None, tries main then master.
 
         Returns:
-            Tuple of (temp_dir_path, cloned_repo_path) where temp_dir_path is
-            the root temporary directory and cloned_repo_path is the repository
-            directory inside it.
+            Tuple of (temp_dir_path, cloned_repo_path, commit_sha) where
+            temp_dir_path is the root temporary directory, cloned_repo_path is
+            the repository directory inside it, and commit_sha is the HEAD
+            commit SHA of the cloned repository.
 
         Raises:
             RuntimeError: If git clone fails for all attempted branches.
@@ -66,7 +67,10 @@ class RepoCloner:
                 check=True,
             )
 
-            return temp_dir, clone_path
+            # Extract HEAD commit SHA
+            commit_sha = self._get_head_commit(clone_path)
+
+            return temp_dir, clone_path, commit_sha
 
         except subprocess.CalledProcessError:
             # If main branch doesn't exist and no specific branch was requested, try master
@@ -88,7 +92,10 @@ class RepoCloner:
                         check=True,
                     )
 
-                    return temp_dir, clone_path
+                    # Extract HEAD commit SHA
+                    commit_sha = self._get_head_commit(clone_path)
+
+                    return temp_dir, clone_path, commit_sha
 
                 except subprocess.CalledProcessError as e:
                     # Clean up and raise
@@ -100,6 +107,26 @@ class RepoCloner:
             # Clean up and raise
             shutil.rmtree(temp_dir, ignore_errors=True)
             raise RuntimeError(f"Failed to clone {repo_url} on branch {branch}")
+
+    def _get_head_commit(self, repo_path: Path) -> str:
+        """Extract HEAD commit SHA from cloned repository.
+
+        Args:
+            repo_path: Path to cloned repository.
+
+        Returns:
+            Full 40-character SHA-1 hash of HEAD commit.
+
+        Raises:
+            RuntimeError: If git rev-parse fails.
+        """
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
 
     def cleanup(self, temp_dir: Path) -> None:
         """Remove temporary directory safely.

--- a/src/troller/worker/services/planning_service.py
+++ b/src/troller/worker/services/planning_service.py
@@ -75,14 +75,14 @@ class PlanningService:
         temp_dir: Path | None = None
 
         try:
-            # Step 1: Clone the repository
-            temp_dir, repo_path = await self._repo_cloner.clone_to_temp(
+            # Step 1: Clone the repository and capture commit SHA
+            temp_dir, repo_path, commit_sha = await self._repo_cloner.clone_to_temp(
                 repo_owner, repo_name, target_branch
             )
 
             # Step 2: Invoke feature-planner skill and parse plan
             plan = await self._generate_plan_with_skill(
-                repo_path, issue_title, issue_body, issue_number
+                repo_path, issue_title, issue_body, issue_number, commit_sha
             )
 
             return plan
@@ -98,6 +98,7 @@ class PlanningService:
         issue_title: str,
         issue_body: str,
         issue_number: int,
+        commit_sha: str,
     ) -> Plan:
         """Generate implementation plan by invoking feature-planner skill.
 
@@ -109,6 +110,7 @@ class PlanningService:
             issue_title: Title of the GitHub issue.
             issue_body: Body/description of the GitHub issue.
             issue_number: Issue number for reference.
+            commit_sha: Git commit SHA the repository is at.
 
         Returns:
             Plan domain object with implementation steps.
@@ -172,16 +174,17 @@ Return a structured plan with:
             raise RuntimeError("Planning agent did not return structured output")
 
         # Convert PlanResponse to Plan domain model
-        return self._convert_to_domain_plan(plan_response, issue_number)
+        return self._convert_to_domain_plan(plan_response, issue_number, commit_sha)
 
     def _convert_to_domain_plan(
-        self, plan_response: PlanResponse, issue_number: int
+        self, plan_response: PlanResponse, issue_number: int, commit_sha: str
     ) -> Plan:
         """Convert validated PlanResponse to Plan domain model.
 
         Args:
             plan_response: Validated Pydantic model from structured output.
             issue_number: GitHub issue number for metadata.
+            commit_sha: Git commit SHA the plan was based on.
 
         Returns:
             Plan domain object with steps converted from PlanStepResponse.
@@ -212,4 +215,5 @@ Return a structured plan with:
             technical_approach=plan_response.technical_approach,
             testing_strategy=plan_response.testing_strategy,
             metadata=metadata,
+            based_on_commit=commit_sha,
         )

--- a/tests/unit/domain/test_plan.py
+++ b/tests/unit/domain/test_plan.py
@@ -215,3 +215,66 @@ def test_plan_immutability() -> None:
 
     with pytest.raises(AttributeError):
         plan.summary = "Changed"  # type: ignore[misc]
+
+
+def test_plan_creation_with_based_on_commit() -> None:
+    """Create a Plan with based_on_commit field."""
+    created_at = datetime.now(timezone.utc)
+    commit_sha = "abc123def456789012345678901234567890abcd"
+
+    plan = Plan(
+        summary="Implement feature X",
+        steps=[],
+        created_at=created_at,
+        based_on_commit=commit_sha,
+    )
+
+    assert plan.summary == "Implement feature X"
+    assert plan.based_on_commit == commit_sha
+    assert plan.created_at == created_at
+
+
+def test_plan_creation_without_based_on_commit() -> None:
+    """Create a Plan without based_on_commit field (should default to None)."""
+    created_at = datetime.now(timezone.utc)
+
+    plan = Plan(
+        summary="Implement feature Y",
+        steps=[],
+        created_at=created_at,
+    )
+
+    assert plan.summary == "Implement feature Y"
+    assert plan.based_on_commit is None
+
+
+def test_plan_with_all_fields_including_commit() -> None:
+    """Create a Plan with all fields including based_on_commit."""
+    created_at = datetime.now(timezone.utc)
+    commit_sha = "1234567890abcdef1234567890abcdef12345678"
+    steps = [
+        PlanStep(
+            id="step-1",
+            description="Implement component",
+            completed=False,
+            related_files=["src/component.py"],
+            estimated_complexity="moderate",
+        ),
+    ]
+
+    plan = Plan(
+        summary="Add new feature with commit tracking",
+        steps=steps,
+        created_at=created_at,
+        technical_approach="Use hexagonal architecture",
+        testing_strategy="TDD with unit tests",
+        metadata={"issue_number": 27},
+        based_on_commit=commit_sha,
+    )
+
+    assert plan.summary == "Add new feature with commit tracking"
+    assert plan.based_on_commit == commit_sha
+    assert plan.technical_approach == "Use hexagonal architecture"
+    assert plan.testing_strategy == "TDD with unit tests"
+    assert plan.metadata["issue_number"] == 27
+    assert len(plan.steps) == 1

--- a/tests/unit/worker/test_planning_service.py
+++ b/tests/unit/worker/test_planning_service.py
@@ -52,7 +52,7 @@ class TestPlanningService:
         # Mock RepoCloner
         mock_cloner = MagicMock(spec=RepoCloner)
         mock_cloner.clone_to_temp = AsyncMock(
-            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"))
+            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"), "abc123")
         )
         mock_cloner.cleanup = MagicMock()
 
@@ -84,7 +84,7 @@ class TestPlanningService:
         temp_dir = MagicMock(spec=Path)
         temp_dir.exists.return_value = True
         mock_cloner.clone_to_temp = AsyncMock(
-            return_value=(temp_dir, Path("/tmp/test/repo"))
+            return_value=(temp_dir, Path("/tmp/test/repo"), "abc123")
         )
         mock_cloner.cleanup = MagicMock()
 
@@ -116,7 +116,7 @@ class TestPlanningService:
         temp_dir = MagicMock(spec=Path)
         temp_dir.exists.return_value = True
         mock_cloner.clone_to_temp = AsyncMock(
-            return_value=(temp_dir, Path("/tmp/test/repo"))
+            return_value=(temp_dir, Path("/tmp/test/repo"), "abc123")
         )
         mock_cloner.cleanup = MagicMock()
 
@@ -149,7 +149,7 @@ class TestPlanningService:
         # Mock RepoCloner
         mock_cloner = MagicMock(spec=RepoCloner)
         mock_cloner.clone_to_temp = AsyncMock(
-            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"))
+            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"), "abc123")
         )
         mock_cloner.cleanup = MagicMock()
 
@@ -183,7 +183,7 @@ class TestPlanningService:
         # Mock RepoCloner
         mock_cloner = MagicMock(spec=RepoCloner)
         mock_cloner.clone_to_temp = AsyncMock(
-            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"))
+            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"), "abc123")
         )
         mock_cloner.cleanup = MagicMock()
 
@@ -218,7 +218,7 @@ class TestPlanningService:
         # Mock RepoCloner
         mock_cloner = MagicMock(spec=RepoCloner)
         mock_cloner.clone_to_temp = AsyncMock(
-            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"))
+            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"), "abc123")
         )
         mock_cloner.cleanup = MagicMock()
 
@@ -250,7 +250,7 @@ class TestPlanningService:
         # Mock RepoCloner
         mock_cloner = MagicMock(spec=RepoCloner)
         mock_cloner.clone_to_temp = AsyncMock(
-            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"))
+            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"), "abc123")
         )
         mock_cloner.cleanup = MagicMock()
 
@@ -296,7 +296,7 @@ class TestPlanningService:
         # Mock RepoCloner
         mock_cloner = MagicMock(spec=RepoCloner)
         mock_cloner.clone_to_temp = AsyncMock(
-            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"))
+            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"), "abc123")
         )
         mock_cloner.cleanup = MagicMock()
 
@@ -331,7 +331,7 @@ class TestPlanningService:
         # Mock RepoCloner
         mock_cloner = MagicMock(spec=RepoCloner)
         mock_cloner.clone_to_temp = AsyncMock(
-            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"))
+            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"), "abc123")
         )
         mock_cloner.cleanup = MagicMock()
 
@@ -362,7 +362,7 @@ class TestPlanningService:
         # Mock RepoCloner
         mock_cloner = MagicMock(spec=RepoCloner)
         mock_cloner.clone_to_temp = AsyncMock(
-            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"))
+            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"), "abc123")
         )
         mock_cloner.cleanup = MagicMock()
 
@@ -398,7 +398,7 @@ class TestPlanningService:
         # Mock RepoCloner
         mock_cloner = MagicMock(spec=RepoCloner)
         mock_cloner.clone_to_temp = AsyncMock(
-            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"))
+            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"), "abc123")
         )
         mock_cloner.cleanup = MagicMock()
 
@@ -422,3 +422,35 @@ class TestPlanningService:
                 repo_owner="owner",
                 repo_name="repo",
             )
+
+    @pytest.mark.asyncio
+    async def test_generate_plan_captures_and_stores_commit_hash(self) -> None:
+        """generate_plan captures commit hash from RepoCloner and stores in Plan."""
+        commit_sha = "abc123def456789012345678901234567890abcd"
+
+        # Mock RepoCloner to return commit hash
+        mock_cloner = MagicMock(spec=RepoCloner)
+        mock_cloner.clone_to_temp = AsyncMock(
+            return_value=(Path("/tmp/test"), Path("/tmp/test/repo"), commit_sha)
+        )
+        mock_cloner.cleanup = MagicMock()
+
+        # Mock Claude client with structured output
+        mock_client = MagicMock(spec=ClaudeClient)
+
+        async def mock_query_response(*args, **kwargs):
+            yield MockStructuredOutputMessage(create_mock_plan_response())
+
+        mock_client.query = mock_query_response
+
+        service = PlanningService(mock_client, mock_cloner)
+        plan = await service.generate_plan(
+            issue_title="Test feature",
+            issue_body="Implement test",
+            issue_number=27,
+            repo_owner="owner",
+            repo_name="repo",
+        )
+
+        # Verify commit hash is stored in Plan
+        assert plan.based_on_commit == commit_sha

--- a/tests/unit/worker/test_repo_cloner.py
+++ b/tests/unit/worker/test_repo_cloner.py
@@ -21,11 +21,14 @@ class TestRepoCloner:
             ) as mock_mkdtemp:
                 # Setup mocks
                 mock_mkdtemp.return_value = "/tmp/troller_testrepo_abc123"
-                mock_run.return_value = MagicMock(returncode=0)
+                mock_run.side_effect = [
+                    MagicMock(returncode=0),  # git clone
+                    MagicMock(returncode=0, stdout="abc123\n"),  # git rev-parse
+                ]
 
                 # Test
                 cloner = RepoCloner()
-                temp_dir, clone_path = await cloner.clone_to_temp(
+                temp_dir, clone_path, _ = await cloner.clone_to_temp(
                     "testowner", "testrepo"
                 )
 
@@ -34,8 +37,8 @@ class TestRepoCloner:
                 assert clone_path == Path("/tmp/troller_testrepo_abc123/testrepo")
 
                 # Verify git clone was called correctly
-                mock_run.assert_called_once()
-                call_args = mock_run.call_args[0][0]
+                assert mock_run.call_count >= 1
+                call_args = mock_run.call_args_list[0][0][0]
                 assert call_args[0] == "git"
                 assert call_args[1] == "clone"
                 assert "--depth" in call_args
@@ -49,13 +52,16 @@ class TestRepoCloner:
         """clone_to_temp uses target_branch when provided."""
         with patch("troller.worker.adapters.repo_cloner.subprocess.run") as mock_run:
             with patch("troller.worker.adapters.repo_cloner.tempfile.mkdtemp"):
-                mock_run.return_value = MagicMock(returncode=0)
+                mock_run.side_effect = [
+                    MagicMock(returncode=0),  # git clone
+                    MagicMock(returncode=0, stdout="abc123\n"),  # git rev-parse
+                ]
 
                 cloner = RepoCloner()
                 await cloner.clone_to_temp("owner", "repo", target_branch="develop")
 
                 # Verify branch is used
-                call_args = mock_run.call_args[0][0]
+                call_args = mock_run.call_args_list[0][0][0]
                 assert "develop" in call_args
 
     @pytest.mark.asyncio
@@ -64,19 +70,22 @@ class TestRepoCloner:
         with patch("troller.worker.adapters.repo_cloner.subprocess.run") as mock_run:
             with patch("troller.worker.adapters.repo_cloner.tempfile.mkdtemp"):
                 with patch("troller.worker.adapters.repo_cloner.shutil.rmtree"):
-                    # First call (main) fails, second call (master) succeeds
+                    # First call (main) fails, second call (master) succeeds, third is rev-parse
                     mock_run.side_effect = [
                         subprocess.CalledProcessError(
                             1, "git", stderr="branch 'main' not found"
                         ),
-                        MagicMock(returncode=0),
+                        MagicMock(returncode=0),  # git clone master
+                        MagicMock(returncode=0, stdout="abc123\n"),  # git rev-parse
                     ]
 
                     cloner = RepoCloner()
-                    temp_dir, clone_path = await cloner.clone_to_temp("owner", "repo")
+                    temp_dir, clone_path, _ = await cloner.clone_to_temp(
+                        "owner", "repo"
+                    )
 
-                    # Verify both branches were tried
-                    assert mock_run.call_count == 2
+                    # Verify both branches were tried plus rev-parse
+                    assert mock_run.call_count == 3
                     first_call_args = mock_run.call_args_list[0][0][0]
                     second_call_args = mock_run.call_args_list[1][0][0]
                     assert "main" in first_call_args
@@ -158,3 +167,71 @@ class TestRepoCloner:
             mock_rmtree.assert_called_once()
             call_kwargs = mock_rmtree.call_args.kwargs
             assert call_kwargs.get("ignore_errors") is True
+
+    @pytest.mark.asyncio
+    async def test_clone_to_temp_returns_commit_sha(self) -> None:
+        """clone_to_temp returns HEAD commit SHA along with paths."""
+        with patch("troller.worker.adapters.repo_cloner.subprocess.run") as mock_run:
+            with patch(
+                "troller.worker.adapters.repo_cloner.tempfile.mkdtemp"
+            ) as mock_mkdtemp:
+                # Setup mocks
+                mock_mkdtemp.return_value = "/tmp/troller_testrepo_abc123"
+
+                # Mock git clone success and git rev-parse HEAD returning commit SHA
+                mock_run.side_effect = [
+                    MagicMock(returncode=0),  # git clone
+                    MagicMock(
+                        returncode=0,
+                        stdout="abc123def456789012345678901234567890abcd\n",
+                    ),  # git rev-parse HEAD
+                ]
+
+                # Test
+                cloner = RepoCloner()
+                temp_dir, clone_path, commit_sha = await cloner.clone_to_temp(
+                    "testowner", "testrepo"
+                )
+
+                # Verify
+                assert temp_dir == Path("/tmp/troller_testrepo_abc123")
+                assert clone_path == Path("/tmp/troller_testrepo_abc123/testrepo")
+                assert commit_sha == "abc123def456789012345678901234567890abcd"
+
+                # Verify git rev-parse was called
+                assert mock_run.call_count == 2
+                rev_parse_call = mock_run.call_args_list[1][0][0]
+                assert rev_parse_call == [
+                    "git",
+                    "-C",
+                    str(clone_path),
+                    "rev-parse",
+                    "HEAD",
+                ]
+
+    @pytest.mark.asyncio
+    async def test_clone_to_temp_returns_commit_sha_after_fallback(self) -> None:
+        """clone_to_temp returns commit SHA even when falling back to master."""
+        with patch("troller.worker.adapters.repo_cloner.subprocess.run") as mock_run:
+            with patch("troller.worker.adapters.repo_cloner.tempfile.mkdtemp"):
+                with patch("troller.worker.adapters.repo_cloner.shutil.rmtree"):
+                    # First call (main) fails, second call (master) succeeds, third is rev-parse
+                    mock_run.side_effect = [
+                        subprocess.CalledProcessError(
+                            1, "git", stderr="branch 'main' not found"
+                        ),
+                        MagicMock(returncode=0),  # git clone master
+                        MagicMock(
+                            returncode=0,
+                            stdout="def456abc789012345678901234567890abcdef1\n",
+                        ),  # git rev-parse HEAD
+                    ]
+
+                    cloner = RepoCloner()
+                    temp_dir, clone_path, commit_sha = await cloner.clone_to_temp(
+                        "owner", "repo"
+                    )
+
+                    # Verify commit SHA is returned
+                    assert commit_sha == "def456abc789012345678901234567890abcdef1"
+                    assert mock_run.call_count == 3


### PR DESCRIPTION
## Summary

Implements commit hash tracking for Plans to enable intelligent re-planning when code changes invalidate existing plans.

## Changes

### Domain Layer
- **src/troller/domain/models/plan.py**: Added `based_on_commit: str | None` field to Plan dataclass

### Adapter Layer
- **src/troller/worker/adapters/repo_cloner.py**: 
  - Added `_get_head_commit()` method to extract HEAD commit SHA
  - Modified `clone_to_temp()` to return `tuple[Path, Path, str]` including commit SHA

### Service Layer
- **src/troller/worker/services/planning_service.py**:
  - Updated to capture commit SHA from RepoCloner
  - Pass commit hash through to Plan creation
  - Store in `based_on_commit` field

### Testing
- **tests/unit/domain/test_plan.py**: Added 3 new tests for Plan with commit tracking
- **tests/unit/worker/test_repo_cloner.py**: Added 2 tests for commit SHA extraction + updated existing tests
- **tests/unit/worker/test_planning_service.py**: Added test for commit hash capture + updated all mocks

## Testing

✓ 65 tests passing
✓ Type checks passing (mypy)
✓ Linting passing (ruff)
✓ Pre-commit hooks passing

## Acceptance Criteria

✓ Every plan is marked with the last commit it was based on
✓ Commit hash captured from cloned repository during plan generation
✓ Full test coverage for new functionality
✓ Type-safe implementation with Python 3.13+ syntax

## Architecture

Follows hexagonal architecture:
- Domain layer has no dependencies (pure business logic)
- Adapter layer handles git operations
- Service layer coordinates the flow
- All dependencies point inward

## Future Work

This implementation provides the foundation for re-planning detection. Future PRs can add:
- Re-planning detection logic in workflows
- Activity to check if current commit differs from plan's base commit
- Automatic re-planning trigger when mismatch detected

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)